### PR TITLE
Fix types alias objects concatenation for complex objects

### DIFF
--- a/packages/orml-type-definitions/src/utils/typesAliasFromDefs.ts
+++ b/packages/orml-type-definitions/src/utils/typesAliasFromDefs.ts
@@ -5,7 +5,7 @@ export default function typesAliasFromDefs(
   initAlias: Record<string, any> = {}
 ): Record<string, any> {
   return Object.values(definitions).reduce(
-    (res: Record<string, any>, { typesAlias }): Record<string, any> => merge(typesAlias, res),
+    (res: Record<string, any>, { typesAlias }): Record<string, any> => merge({}, typesAlias, res),
     initAlias
   );
 }

--- a/packages/orml-type-definitions/src/utils/typesAliasFromDefs.ts
+++ b/packages/orml-type-definitions/src/utils/typesAliasFromDefs.ts
@@ -1,12 +1,11 @@
+import merge from 'lodash/merge'
+
 export default function typesAliasFromDefs(
   definitions: Record<string, Record<string, any>>,
   initAlias: Record<string, any> = {}
 ): Record<string, any> {
   return Object.values(definitions).reduce(
-    (res: Record<string, any>, { typesAlias }): Record<string, any> => ({
-      ...res,
-      ...typesAlias
-    }),
+    (res: Record<string, any>, { typesAlias }): Record<string, any> => merge(typesAlias, res),
     initAlias
   );
 }

--- a/packages/orml-type-definitions/src/utils/typesAliasFromDefs.ts
+++ b/packages/orml-type-definitions/src/utils/typesAliasFromDefs.ts
@@ -1,4 +1,4 @@
-import merge from 'lodash/merge'
+import merge from 'lodash/merge';
 
 export default function typesAliasFromDefs(
   definitions: Record<string, Record<string, any>>,


### PR DESCRIPTION
<h1>Description</h1>
<p>I've fixed an issue with objects concatenation for complex objects. Let's check an example below:</p>

1) `ormlAlias`: `{ tokens: { AccountData: 'OrmlAccountData', BalanceLock: 'OrmlBalanceLock' } }`
2) `internalAlias`: `{ tokens: { Something: 'Something' } }`

As a result of `typesAliasFromDefs(internalAlias, { ...ormlAlias })` function I want to see the following structure:
```
{
  tokens: {
    Something: 'Something',
    AccountData: 'OrmlAccountData',
    BalanceLock: 'OrmlBalanceLock'
}
```