### PR TITLE
Fix indexer issue with sudo

### DIFF
--- a/packages/indexer/src/indexer.ts
+++ b/packages/indexer/src/indexer.ts
@@ -422,7 +422,7 @@ export default class Indexer {
           );
         });
       } else if (call.section === 'sudo' && call.method === 'sudo') {
-        const childCall = call.args.call as ChildCall;
+        const childCall = (call.args.call || call.args.proposal) as ChildCall;
         const { section, method } = decodeCallIndex(childCall.callIndex);
         handle(
           {


### PR DESCRIPTION
## Fix indexer issues with `Sudo` module's `sudo` call

### Background

When using indexer for `Kusama` chain some percentage of blocks fail with error:

```
error: 9254-0x03437618988d49427ee37e0c3d5bd8f7b46bdd0fbafe6108d985b1578f0b0b73   
Cannot read  property 'callIndex' of undefined {"stack":"TypeError: Cannot read property 'callIndex' of undefined at handle  
(<path>/@open-web3/indexer/indexer.js:411:39)\n    at   Indexer.syncDispatchableCalls (<path>/indexer/node_modules/@open-web3/indexer/indexer.js:422:7)\n    
at Indexer.pushData   (<path>/indexer/node_modules/@open-   web3/indexer/indexer.js:199:18)\n  
at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (internal/process/task_queues.js:97:5)\n
at async SafeSubscriber._next(<path>/indexer/node_modules/@openweb3/indexer/indexer.js:109:9)",  
"timestamp":"2021-07-11 02:32:32","errorCode":2}
```

This same error repeats for several blocks (9370, 9369, etc.). The error is generated in this line of code:
```
else if (call.section === 'sudo' && call.method === 'sudo') {
        const childCall = call.args.call as ChildCall;
```

After some debugging, I have found out that name of dispatchable call of `Sudo` pallet initially was named `proposal` and consequently, `sudo` function receives parameter named `proposal`. The name was changed from `proposal` to `call` in this pr: https://github.com/paritytech/substrate/pull/4946

This pr fixes this issue.


 