### PR TITLE
Network specific address decoding

### DIFF
--- a/packages/indexer/src/indexer.ts
+++ b/packages/indexer/src/indexer.ts
@@ -36,7 +36,8 @@ export default class Indexer {
 
     const wsProvider = new WsProvider(options.wsUrl);
 
-    const api = await ApiPromise.create({ provider: wsProvider });
+    // if I don't instantiate ApiPromise from wsProvider, it fails with `Error: Websocket not connected`
+    const _api = await ApiPromise.create({ provider: wsProvider });
 
     log.info('Init DB');
 
@@ -57,7 +58,6 @@ export default class Indexer {
         typesSpec: options.typesSpec,
         typesChain: options.typesChain,
         typesBundle: options.typesBundle,
-        api
       })
     );
   }

--- a/packages/indexer/src/indexer.ts
+++ b/packages/indexer/src/indexer.ts
@@ -1,5 +1,6 @@
 import { Sequelize, Op, Options, SyncOptions } from 'sequelize';
 import { Registry } from '@polkadot/types/types';
+import { ApiPromise } from '@polkadot/api';
 import { WsProvider } from '@polkadot/rpc-provider';
 import { auditTime, mergeMap } from 'rxjs/operators';
 import Scanner from '@open-web3/scanner';
@@ -35,6 +36,8 @@ export default class Indexer {
 
     const wsProvider = new WsProvider(options.wsUrl);
 
+    const api = await ApiPromise.create({ provider: wsProvider });
+
     log.info('Init DB');
 
     init(db);
@@ -53,7 +56,8 @@ export default class Indexer {
         typesAlias: options.typesAlias,
         typesSpec: options.typesSpec,
         typesChain: options.typesChain,
-        typesBundle: options.typesBundle
+        typesBundle: options.typesBundle,
+        api
       })
     );
   }

--- a/packages/indexer/src/indexer.ts
+++ b/packages/indexer/src/indexer.ts
@@ -1,6 +1,5 @@
 import { Sequelize, Op, Options, SyncOptions } from 'sequelize';
 import { Registry } from '@polkadot/types/types';
-import { ApiPromise } from '@polkadot/api';
 import { WsProvider } from '@polkadot/rpc-provider';
 import { auditTime, mergeMap } from 'rxjs/operators';
 import Scanner from '@open-web3/scanner';
@@ -35,9 +34,6 @@ export default class Indexer {
     await db.authenticate();
 
     const wsProvider = new WsProvider(options.wsUrl);
-
-    // if I don't instantiate ApiPromise from wsProvider, it fails with `Error: Websocket not connected`
-    const _api = await ApiPromise.create({ provider: wsProvider });
 
     log.info('Init DB');
 

--- a/packages/indexer/src/indexer.ts
+++ b/packages/indexer/src/indexer.ts
@@ -57,7 +57,7 @@ export default class Indexer {
         typesAlias: options.typesAlias,
         typesSpec: options.typesSpec,
         typesChain: options.typesChain,
-        typesBundle: options.typesBundle,
+        typesBundle: options.typesBundle
       })
     );
   }

--- a/packages/indexer/src/indexer.ts
+++ b/packages/indexer/src/indexer.ts
@@ -422,7 +422,7 @@ export default class Indexer {
           );
         });
       } else if (call.section === 'sudo' && call.method === 'sudo') {
-        const childCall = call.args.call as ChildCall;
+        const childCall = (call.args.call || call.args.proposal) as ChildCall;
         const { section, method } = decodeCallIndex(childCall.callIndex);
         handle(
           {

--- a/packages/scanner/src/Scanner.ts
+++ b/packages/scanner/src/Scanner.ts
@@ -45,11 +45,11 @@ class Scanner {
     this.wsProvider = options.wsProvider;
     this.rpcProvider = options.rpcProvider || options.wsProvider;
     this.knownTypes = {
-      types: options.types || options.api?.registry.knownTypes.types,
-      typesAlias: options.typesAlias || options.api?.registry.knownTypes.typesAlias,
-      typesBundle: options.typesBundle || options.api?.registry.knownTypes.typesBundle,
-      typesChain: options.typesChain || options.api?.registry.knownTypes.typesChain,
-      typesSpec: options.typesSpec || options.api?.registry.knownTypes.typesSpec
+      types: options.types,
+      typesAlias: options.typesAlias,
+      typesBundle: options.typesBundle,
+      typesChain: options.typesChain,
+      typesSpec: options.typesSpec
     };
     this.chainInfo = {};
     this.metadataRequest = {};

--- a/packages/scanner/src/types.ts
+++ b/packages/scanner/src/types.ts
@@ -1,4 +1,3 @@
-import { ApiPromise } from '@polkadot/api';
 import { DecoratedMeta } from '@polkadot/metadata/decorate/types';
 import { HttpProvider, WsProvider as _WsProvider } from '@polkadot/rpc-provider';
 import { Registry } from '@polkadot/types/types';
@@ -6,7 +5,6 @@ import { RegisteredTypes as _RegisteredTypes } from '@polkadot/types/types/regis
 
 export type WsProvider = _WsProvider;
 export type RpcProvider = _WsProvider | HttpProvider;
-export type ApiType = ApiPromise | undefined;
 
 export type Hex = string;
 export type Bytes = string;
@@ -25,7 +23,6 @@ export interface Extrinsic extends DispatchableCall {
 export interface ScannerOptions extends _RegisteredTypes {
   wsProvider: WsProvider;
   rpcProvider?: RpcProvider;
-  api?: ApiPromise;
 }
 
 export type RegisteredTypes = _RegisteredTypes;

--- a/packages/scanner/src/types.ts
+++ b/packages/scanner/src/types.ts
@@ -1,10 +1,12 @@
-import { WsProvider as _WsProvider, HttpProvider } from '@polkadot/rpc-provider';
-import { RegisteredTypes as _RegisteredTypes } from '@polkadot/types/types/registry';
+import { ApiPromise } from '@polkadot/api';
 import { DecoratedMeta } from '@polkadot/metadata/decorate/types';
+import { HttpProvider, WsProvider as _WsProvider } from '@polkadot/rpc-provider';
 import { Registry } from '@polkadot/types/types';
+import { RegisteredTypes as _RegisteredTypes } from '@polkadot/types/types/registry';
 
 export type WsProvider = _WsProvider;
 export type RpcProvider = _WsProvider | HttpProvider;
+export type ApiType = ApiPromise | undefined;
 
 export type Hex = string;
 export type Bytes = string;
@@ -23,6 +25,7 @@ export interface Extrinsic extends DispatchableCall {
 export interface ScannerOptions extends _RegisteredTypes {
   wsProvider: WsProvider;
   rpcProvider?: RpcProvider;
+  api?: ApiPromise;
 }
 
 export type RegisteredTypes = _RegisteredTypes;


### PR DESCRIPTION
## Issue 1

Currently [`indexer`](https://github.com/open-web3-stack/open-web3.js/tree/master/packages/indexer) decodes and stores `SS58` addresses in a generic `Substrate` format, i.e with prefix `5`. I think it would be good enhancement to make it detect the format prefix and decode addresses as belonging to the specific network. `Polkadot` addresses start with a prefix `1`, `Kusama` `G, H, F, etc.` letters.

For more information about address formats, [click here](https://wiki.polkadot.network/docs/learn-accounts#address-format).

This PR will fix this issue by detecting network address prefix and injecting it to registry, so that addresses are stored in a correct format.

## Issue 2

If you try to index remote `Substrate` archive node, both `Scanner` and `Indexer` fails to connect to websocket address with this error:

```bash
Error: WebSocket is not connected
```

The code is:
```js
  ...
  const wsUrl = 'wss://kusama-rpc.polkadot.io';
  const wsProvider = new WsProvider(wsUrl, 100);

  const scanner = new Scanner({
    wsProvider,
  });
  ...
```
 
Strangely this error disappears if you instantiate `ApiPromise` from the `WsProvider` instance. 

```js
...
  const wsUrl = 'wss://kusama-rpc.polkadot.io';
  const wsProvider = new WsProvider(wsUrl, 100);
  const _api = await ApiPromise.create({ provider: wsProvider });
  
  const scanner = new Scanner({
    wsProvider,
  });
...
```

This issue arises only while indexing remote nodes, local sync nodes work fine. 

Changes made in the `indexer.ts` file also fix this issue.